### PR TITLE
Fix Auto Merge not working on PRs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,24 +1,25 @@
 name: AutoMerge
 
 on:
-    pull_request:
-        types: [labeled, opened, edited, reopened, synchronized]
-    pull_request_review:
-        types: [submitted, edited]
-    check_suite:
-        types: [completed]
-    status: {}
+  pull_request:
+    types: [labeled, opened, edited, reopened, synchronized]
+    branches:
+      - dev
+  pull_request_review:
+    types: [submitted, edited]
+  check_suite:
+    types: [completed]
 
 jobs:
-    AutoMerge:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Auto Merge
-              uses: "pascalgn/automerge-action@v0.13.1"
-              env:
-                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-                  MERGE_REMOVE_LABELS: "automerge"
-                  MERGE_METHOD: "rebase"
-                  MERGE_COMMIT_MESSAGE: "Automerged {pullRequest.number}"
-                  MERGE_RETRIES: "50"
-                  MERGE_RETRY_SLEEP: "30000"
+  AutoMerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Merge
+        uses: "pascalgn/automerge-action@v0.13.1"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_REMOVE_LABELS: "automerge"
+          MERGE_METHOD: "rebase"
+          MERGE_COMMIT_MESSAGE: "Automerged {pullRequest.number}"
+          MERGE_RETRIES: "50"
+          MERGE_RETRY_SLEEP: "30000"


### PR DESCRIPTION
## Description

The Auto-Merge workflow doesn't work always as expected. It fails when Dependabot opens a PR. Here's an example workflow: https://github.com/Jarmos-san/blog/runs/2242046559?check_suite_focus=true

Fixes #55

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
